### PR TITLE
fix!: Remove mappings for frontend registration URLs

### DIFF
--- a/nginx/conf/locations/addiction.conf
+++ b/nginx/conf/locations/addiction.conf
@@ -15,6 +15,3 @@ location = /suchtberatung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /03pages.01registrationFormular.html {
-    return 301 /suchtberatung/registration;
-}

--- a/nginx/conf/locations/addiction.conf
+++ b/nginx/conf/locations/addiction.conf
@@ -15,22 +15,6 @@ location = /suchtberatung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /suchtberatung/registration {
-    proxy_pass http://frontend:80/registration.suchtberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /suchtberatung/registration/ {
-    proxy_pass http://frontend:80/registration.suchtberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
 location = /03pages.01registrationFormular.html {
     return 301 /suchtberatung/registration;
 }

--- a/nginx/conf/locations/aids.conf
+++ b/nginx/conf/locations/aids.conf
@@ -15,19 +15,3 @@ location = /hiv-aids-beratung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /hiv-aids-beratung/registration {
-    proxy_pass http://frontend:80/registration.hiv-aids-beratung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /hiv-aids-beratung/registration/ {
-    proxy_pass http://frontend:80/registration.hiv-aids-beratung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/children.conf
+++ b/nginx/conf/locations/children.conf
@@ -15,19 +15,3 @@ location = /kinder-jugendliche/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /kinder-jugendliche/registration {
-    proxy_pass http://frontend:80/registration.kinder-jugendliche.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /kinder-jugendliche/registration/ {
-    proxy_pass http://frontend:80/registration.kinder-jugendliche.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/cure.conf
+++ b/nginx/conf/locations/cure.conf
@@ -15,19 +15,3 @@ location = /kurberatung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /kurberatung/registration {
-    proxy_pass http://frontend:80/registration.kurberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /kurberatung/registration/ {
-    proxy_pass http://frontend:80/registration.kurberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/debt.conf
+++ b/nginx/conf/locations/debt.conf
@@ -15,19 +15,3 @@ location = /schuldnerberatung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /schuldnerberatung/registration {
-    proxy_pass http://frontend:80/registration.schuldnerberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /schuldnerberatung/registration/ {
-    proxy_pass http://frontend:80/registration.schuldnerberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/disability.conf
+++ b/nginx/conf/locations/disability.conf
@@ -15,19 +15,3 @@ location = /behinderung-und-psychische-erkrankung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /behinderung-und-psychische-erkrankung/registration {
-    proxy_pass http://frontend:80/registration.behinderung-und-psychische-erkrankung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /behinderung-und-psychische-erkrankung/registration/ {
-    proxy_pass http://frontend:80/registration.behinderung-und-psychische-erkrankung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/emigration.conf
+++ b/nginx/conf/locations/emigration.conf
@@ -15,19 +15,3 @@ location = /rw-auswanderung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /rw-auswanderung/registration {
-    proxy_pass http://frontend:80/registration.rw-auswanderung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /rw-auswanderung/registration/ {
-    proxy_pass http://frontend:80/registration.rw-auswanderung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/hospice.conf
+++ b/nginx/conf/locations/hospice.conf
@@ -15,19 +15,3 @@ location = /hospiz-palliativ/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /hospiz-palliativ/registration {
-    proxy_pass http://frontend:80/registration.hospiz-palliativ.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /hospiz-palliativ/registration/ {
-    proxy_pass http://frontend:80/registration.hospiz-palliativ.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/kreuzbund.conf
+++ b/nginx/conf/locations/kreuzbund.conf
@@ -15,19 +15,3 @@ location = /kb-sucht-selbsthilfe/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /kb-sucht-selbsthilfe/registration {
-    proxy_pass http://frontend:80/registration.kb-sucht-selbsthilfe.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /kb-sucht-selbsthilfe/registration/ {
-    proxy_pass http://frontend:80/registration.kb-sucht-selbsthilfe.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/law.conf
+++ b/nginx/conf/locations/law.conf
@@ -15,19 +15,3 @@ location = /rechtliche-betreuung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /rechtliche-betreuung/registration {
-    proxy_pass http://frontend:80/registration.rechtliche-betreuung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /rechtliche-betreuung/registration/ {
-    proxy_pass http://frontend:80/registration.rechtliche-betreuung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/migration.conf
+++ b/nginx/conf/locations/migration.conf
@@ -15,19 +15,3 @@ location = /migration/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /migration/registration {
-    proxy_pass http://frontend:80/registration.migration.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /migration/registration/ {
-    proxy_pass http://frontend:80/registration.migration.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/offender.conf
+++ b/nginx/conf/locations/offender.conf
@@ -15,19 +15,3 @@ location = /straffaelligkeit/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /straffaelligkeit/registration {
-    proxy_pass http://frontend:80/registration.straffaelligkeit.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /straffaelligkeit/registration/ {
-    proxy_pass http://frontend:80/registration.straffaelligkeit.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/parenting.conf
+++ b/nginx/conf/locations/parenting.conf
@@ -15,19 +15,3 @@ location = /eltern-familie/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /eltern-familie/registration {
-    proxy_pass http://frontend:80/registration.eltern-familie.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /eltern-familie/registration/ {
-    proxy_pass http://frontend:80/registration.eltern-familie.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/planb.conf
+++ b/nginx/conf/locations/planb.conf
@@ -15,19 +15,3 @@ location = /mein-planb/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /mein-planb/registration {
-    proxy_pass http://frontend:80/registration.mein-planb.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /mein-planb/registration/ {
-    proxy_pass http://frontend:80/registration.mein-planb.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/pregnancy.conf
+++ b/nginx/conf/locations/pregnancy.conf
@@ -15,19 +15,3 @@ location = /schwangerschaftsberatung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /schwangerschaftsberatung/registration {
-    proxy_pass http://frontend:80/registration.schwangerschaftsberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /schwangerschaftsberatung/registration/ {
-    proxy_pass http://frontend:80/registration.schwangerschaftsberatung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/regional.conf
+++ b/nginx/conf/locations/regional.conf
@@ -15,19 +15,3 @@ location = /regionale-angebote/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /regionale-angebote/registration {
-    proxy_pass http://frontend:80/registration.regionale-angebote.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /regionale-angebote/registration/ {
-    proxy_pass http://frontend:80/registration.regionale-angebote.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/rehabilitation.conf
+++ b/nginx/conf/locations/rehabilitation.conf
@@ -15,19 +15,3 @@ location = /kinder-reha/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /kinder-reha/registration {
-    proxy_pass http://frontend:80/registration.kinder-reha.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /kinder-reha/registration/ {
-    proxy_pass http://frontend:80/registration.kinder-reha.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/seniority.conf
+++ b/nginx/conf/locations/seniority.conf
@@ -15,19 +15,3 @@ location = /leben-im-alter/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /leben-im-alter/registration {
-    proxy_pass http://frontend:80/registration.leben-im-alter.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /leben-im-alter/registration/ {
-    proxy_pass http://frontend:80/registration.leben-im-alter.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/social.conf
+++ b/nginx/conf/locations/social.conf
@@ -15,19 +15,3 @@ location = /allgemeine-soziale-beratung/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /allgemeine-soziale-beratung/registration {
-    proxy_pass http://frontend:80/registration.allgemeine-soziale-beratung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /allgemeine-soziale-beratung/registration/ {
-    proxy_pass http://frontend:80/registration.allgemeine-soziale-beratung.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/u25.conf
+++ b/nginx/conf/locations/u25.conf
@@ -15,25 +15,3 @@ location = /u25/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /u25/registration {
-    if ($arg_aid = "") {
-        return 301 https://www.u25.de/helpmail/;
-    }
-    proxy_pass http://frontend:80/registration.u25.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /u25/registration/ {
-    if ($arg_aid = "") {
-        return 301 https://www.u25.de/helpmail/;
-    }
-    proxy_pass http://frontend:80/registration.u25.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}

--- a/nginx/conf/locations/united.conf
+++ b/nginx/conf/locations/united.conf
@@ -15,25 +15,3 @@ location = /gemeinsamstatteinsam/ {
     proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
-location = /gemeinsamstatteinsam/registration {
-    if ($arg_aid = "") {
-        return 301 https://www.u25.de/helpmail/;
-    }
-    proxy_pass http://frontend:80/registration.gemeinsamstatteinsam.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-location = /gemeinsamstatteinsam/registration/ {
-    if ($arg_aid = "") {
-        return 301 https://www.u25.de/helpmail/;
-    }
-    proxy_pass http://frontend:80/registration.gemeinsamstatteinsam.html;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}


### PR DESCRIPTION
Related fix for https://github.com/virtualidentityag/diakonie-onlineBeratung-frontend/pull/4

I've tested this locally by [mounting the built app from the linked branch](https://caritasdeutschland.github.io/documentation/docs/backend/install-and-running-locally#_optional_-frontend-konfiguration-anpassen) in the local backend. It seems like the proxy passes through all unknown calls to the frontend and so we can utilise SPA routing without having to configure anything in NGINX.

The new URLs work both with trailing slashes as well as without. I've checked all registration URLs manually. Also the U25 and gemeinsamstatteinsam redirect continues to work when no `aid` is passed.